### PR TITLE
キャラクターページ調整

### DIFF
--- a/app/assets/stylesheets/add_styles.css
+++ b/app/assets/stylesheets/add_styles.css
@@ -259,6 +259,7 @@ body{
   height: 800px;
 }
 
+/* 立ち絵枠線 */
 .drop-area {
   width: 100%;
   height: 90%;
@@ -271,6 +272,7 @@ body{
   overflow: hidden;
 }
 
+/* 立ち絵表示 */
 .drop-area img {
   max-width: 100%;
   max-height: 100%;
@@ -288,4 +290,9 @@ body{
 .character-row {
   flex-wrap: wrap;
   align-items: center;
+}
+
+/* 立ち絵フォーム非表示 */
+#imageInput {
+  display: none;
 }

--- a/app/views/public/characters/_character.html.erb
+++ b/app/views/public/characters/_character.html.erb
@@ -10,15 +10,17 @@
   <%= form_with model: @character, local: true do |f| %>
     <div class="row character-row">
       <div class="col-md-6">
-        <div class="col-md-8">
+        <div class="col-md-11">
           <div class="image-upload-container">
-            <input type="file" id="imageInput" accept="image/*" hidden>
-            <div id="imageDropArea" class="drop-area">
-              <p id="dropAreaText">画像をドラッグ＆ドロップ または クリックして選択</p>
-              <img id="previewImage" src="" alt="Preview" class="hidden">
-            </div>
+            <% if action_name == "new" || action_name == "edit" %>
+              <%= f.file_field :standing_picture, accept: "image/*", id: "imageInput", class: "form-control col-md-11 mt-3" %>
+              <div id="imageDropArea" class="drop-area">
+                <p id="dropAreaText">画像をドラッグ＆ドロップ または クリックして選択</p>
+                <img id="previewImage" src="" alt="Preview" class="hidden">
+              </div>
+            <% end %>
           </div>
-          <button id="deleteImage" class="hidden btn btn-danger text-center">削除</button>
+          <%= button_tag "削除", id: "deleteImage", type: "button", class: "hidden btn btn-danger" %>
         </div>
       </div>
        


### PR DESCRIPTION
前日の問題点修正
・立ち絵枠線、内部のテキストshowページでの非表示
・立ち絵削除ボタンを押すと問題なく画像削除

【要確認】
- 背景画像、立ち絵が保存されない (Javascriptの影響確認)